### PR TITLE
New protection list via VECSXP

### DIFF
--- a/inst/include/cpp20/r_protect.h
+++ b/inst/include/cpp20/r_protect.h
@@ -2,6 +2,7 @@
 #define CPP20_R_PROTECT_H
 
 #include <csetjmp>
+#include <cstdint> // For fixed-width int types
 #include <exception>
 #include <cpp20/r_setup.h>
 
@@ -14,14 +15,20 @@ public:
     explicit unwind_exception(SEXP token_) : token(token_) {}
 };
 
-// The core unwind_protect (no tuple/gcc4.8 hacks)
-template <typename Fun>
-auto unwind_protect(Fun&& code) -> decltype(code()) {
+// One shared unwind continuation for the whole shared library.
+inline SEXP unwind_token() {
     static SEXP token = [] {
         SEXP res = R_MakeUnwindCont();
         R_PreserveObject(res);
         return res;
     }();
+    return token;
+}
+
+// The core unwind_protect (no tuple/gcc4.8 hacks)
+template <typename Fun>
+auto unwind_protect(Fun&& code) -> decltype(code()) {
+    SEXP token = unwind_token();
 
     std::jmp_buf jmpbuf;
     if (setjmp(jmpbuf)) {
@@ -107,70 +114,317 @@ inline void print(const char* msg) {
 }
 
 namespace detail {
-namespace store {
+namespace vec_store {
 
-inline SEXP init() {
-    SEXP out = Rf_cons(R_NilValue, Rf_cons(R_NilValue, R_NilValue));
-    R_PreserveObject(out);
-    return out;
-}
+// ---------------------------------------------------------------------------
+// Chunked VECSXP-backed protection pool
+//
+// The pool is a singly-linked chain of "chunks". Each chunk is one VECSXP
+// (independently R_PreserveObject'd) plus a small C++ control block:
+//
+//   chunk { vec=VECSXP[capacity], capacity, free_count, free_stack[capacity],
+//           next, free_next }
+//
+// Slot lifetime within a chunk is tracked by a per-chunk LIFO freelist of
+// integer slot indices (`free_stack`). Insert pops the next free slot and
+// writes the protected SEXP via SET_VECTOR_ELT (write-barrier safe). Release
+// clears the slot back to R_NilValue and pushes the index onto free_stack.
+//
+// Two intrusive lists are threaded through `chunk`:
+//   * `next`      -- the master allocation chain (every chunk ever created).
+//                    Used only for diagnostics (count/print).
+//   * `free_next` -- the "has free slots" list. A chunk is on this list iff
+//                    its free_count > 0. This makes both insert and release
+//                    O(1) on every path, hot or cold -- there is no
+//                    chain walk anywhere. When a chunk fills, it is unlinked
+//                    from the free list; when a previously-full chunk has a
+//                    slot released, it is pushed back onto the free list.
+//
+// New chunks double in capacity (256, 512, 1024, ...) up to `max_chunk_size`.
+// Crucially, growing the pool means *appending* a new chunk -- existing
+// chunks are never copied or moved, so all outstanding `slot_ref` tokens
+// remain valid forever
+//
+// Memory behaviour:
+//   * The pool tracks the actual current working set, not the historical
+//     peak. When a chunk becomes entirely empty (free_count == capacity)
+//     it is R_ReleaseObject'd and freed in `release()`, with one exception:
+//     we always keep at least one chunk alive as a scratchpad to avoid
+//     allocate-then-free thrashing at burst boundaries.
+//   * This matters because R's GC marks every slot of a VECSXP up to its
+//     length, not just the populated ones -- a 16384-slot chunk holding
+//     three live objects still costs ~16384 pointer reads per GC cycle.
+//     Releasing empty chunks keeps GC scan cost proportional to actual
+//     working-set size.
+//   * `next_size` (chunk capacity for the next allocation) is watermark-
+//     only: it never shrinks. Once it reaches max_chunk_size all subsequent
+//     chunks are allocated at that size. The reasoning: if we needed a big
+//     chunk once, we'll likely need one again, and over-allocating beats
+//     repeated doubling on every burst.
+//   * `protect_cell` C++ control blocks are recycled via a small freelist
+//     and never released back to the heap. Bounded by peak concurrent
+//     refcount-distinct r_sexp count, which is small in practice.
+//
+// Threading:
+//   * Not thread-safe. All state (head_chunk, free_list_head, the per-chunk
+//     free_stack and free_count) is shared process-global with no locking.
+//     This matches R itself, which is single-threaded -- the R API is not
+//     reentrant from parallel threads. **Do not construct r_sexp / r_str /
+//     r_vec from inside an OpenMP parallel region.** Read-only access via
+//     view_tag or r_str_view is safe because it never touches the pool.
+//
+// Trade-offs vs the previous cons-cell linked list:
+//   + 1 R-side allocation per *chunk* instead of 1 per cell -- far fewer
+//     calls into R's allocator and far fewer GC roots.
+//   + Linear memory layout: chunk slots are contiguous, so the hot path
+//     touches one cache line for many consecutive inserts/releases.
+//   + Slightly larger token (chunk* + int instead of a single SEXP), but
+//     refcount means most copies don't allocate a token at all.
+//   - Per-chunk freelist introduces a tiny C++-side allocation (`new int[]`),
+//     amortised across the entire chunk.
+// ---------------------------------------------------------------------------
 
-inline SEXP get() {
-    // Note the `static` local variable in the inline extern function here! Guarantees we
-    // have 1 unique preserve list across all compilation units in the package.
-    static SEXP out = init();
-    return out;
-}
+struct chunk {
+    SEXP   vec;         // VECSXP, R_PreserveObject'd
+    int    capacity;
+    int    free_count;  // slots currently free in this chunk
+    int*   free_stack;  // [capacity] indices of free slots (LIFO)
+    chunk* next;        // master allocation chain (forward link)
+    chunk* prev;        // master allocation chain (back link, for O(1) unlink)
+    chunk* free_next;   // intrusive "has free slots" list; nullptr if full
+};
 
-inline R_xlen_t count() {
-    const R_xlen_t head = 1;
-    const R_xlen_t tail = 1;
-    SEXP list = get();
-    return Rf_xlength(list) - head - tail;
-}
+// Token returned by insert; opaque to callers other than `release`.
+struct slot_ref {
+    chunk* c;     // owning chunk (nullptr means "no slot / R_NilValue")
+    int    slot;  // index within c->vec
+};
 
-inline SEXP insert(SEXP x) {
-    if (x == R_NilValue) {
-        return R_NilValue;
+// Singletons (one per shared library via `static` in inline functions).
+//   head_chunk     -- master chain of every chunk ever allocated
+//   free_list_head -- head of the intrusive "has free slots" list
+inline chunk*& head_chunk()     { static chunk* head = nullptr; return head; }
+inline chunk*& free_list_head() { static chunk* head = nullptr; return head; }
+
+// Allocate a new chunk and push it onto both the master chain and the
+// free list. Capacity doubles each time, capped at `max_chunk_size`. Caller
+// is responsible for protecting any SEXPs that must outlive this allocation.
+inline chunk* add_chunk() {
+    // Start at 1024 slots: skips two doublings of warmup so the first
+    // ~thousand protections in any .Call don't trigger any growth, while
+    // staying small enough that GC scan cost stays trivial when the chunk
+    // is sparsely populated)
+    constexpr int first_chunk_size = 1024;
+    constexpr int max_chunk_size   = 16384;
+    static int next_size = first_chunk_size;
+
+    int cap = next_size;
+    SEXP v = safe[Rf_allocVector](VECSXP, cap);
+    R_PreserveObject(v);
+
+    chunk* c = new chunk{};
+    c->vec        = v;
+    c->capacity   = cap;
+    c->free_count = cap;
+    c->free_stack = new int[cap];
+    // Fill the freelist so slot 0 is popped first (LIFO).
+    for (int i = 0; i < cap; ++i) {
+        c->free_stack[i] = cap - 1 - i;
     }
 
-    Rf_protect(x);
+    // Link into master chain (doubly-linked for O(1) unlink in release).
+    c->prev = nullptr;
+    c->next = head_chunk();
+    if (c->next != nullptr) {
+        c->next->prev = c;
+    }
+    head_chunk() = c;
 
-    SEXP list = get();
-    SEXP head = list;
-    SEXP next = CDR(list);
+    // Link into "has free slots" list (it's empty, so it definitely has free).
+    c->free_next = free_list_head();
+    free_list_head() = c;
 
-    SEXP cell = Rf_protect(Rf_cons(head, next));
-    SET_TAG(cell, x);
-
-    SETCDR(head, cell);
-    SETCAR(next, cell);
-
-    Rf_unprotect(2);
-    return cell;
+    if (next_size < max_chunk_size) {
+        next_size *= 2;
+    }
+    return c;
 }
 
-inline void release(SEXP cell) {
-    if (cell == R_NilValue) {
+// Permanently free a chunk: unlink from both lists, release the VECSXP back
+// to R, and delete the C++ control block. Caller must guarantee `c` has no
+// live slots and is not the only chunk in existence.
+inline void destroy_chunk(chunk* c) noexcept {
+    // Unlink from master chain (doubly linked).
+    if (c->prev != nullptr) {
+        c->prev->next = c->next;
+    } else {
+        head_chunk() = c->next;
+    }
+    if (c->next != nullptr) {
+        c->next->prev = c->prev;
+    }
+
+    // Unlink from free list (singly linked -- walk to find predecessor).
+    chunk** link = &free_list_head();
+    while (*link != nullptr && *link != c) {
+        link = &(*link)->free_next;
+    }
+    if (*link == c) {
+        *link = c->free_next;
+    }
+
+    R_ReleaseObject(c->vec);
+    delete[] c->free_stack;
+    delete c;
+}
+
+inline slot_ref insert(SEXP x) {
+    if (x == R_NilValue) {
+        return {nullptr, -1};
+    }
+
+    chunk* c = free_list_head();
+    if (c == nullptr) {
+        // Every chunk is full (or none exist). Allocate a new one.
+        // Allocation may GC, so protect `x` for the duration.
+        Rf_protect(x);
+        c = add_chunk();
+        Rf_unprotect(1);
+        // add_chunk pushed c onto free_list_head, so it's the new head.
+    }
+
+    int slot = c->free_stack[--c->free_count];
+    SET_VECTOR_ELT(c->vec, slot, x);
+
+    // If this chunk just became full, unlink it from the free list.
+    if (c->free_count == 0) {
+        free_list_head() = c->free_next;
+        c->free_next = nullptr;
+    }
+
+    return {c, slot};
+}
+
+inline void release(slot_ref ref) noexcept {
+    if (ref.c == nullptr) {
         return;
     }
-    SEXP lhs = CAR(cell);
-    SEXP rhs = CDR(cell);
-    SETCDR(lhs, rhs);
-    SETCAR(rhs, lhs);
+    chunk* c = ref.c;
+    SET_VECTOR_ELT(c->vec, ref.slot, R_NilValue);
+
+    bool was_full = (c->free_count == 0);
+    c->free_stack[c->free_count++] = ref.slot;
+
+    // If the chunk was full, it wasn't on the free list -- put it back.
+    if (was_full) {
+        c->free_next = free_list_head();
+        free_list_head() = c;
+    }
+
+    // If the chunk is now entirely empty, free it back to R -- but always
+    // keep at least one chunk alive as a scratchpad. Without the guard, a
+    // workload that protects exactly one object at a time and releases it
+    // immediately would allocate-then-free a chunk on every cycle.
+    if (c->free_count == c->capacity && head_chunk() != nullptr &&
+        head_chunk()->next != nullptr) {
+        destroy_chunk(c);
+    }
+}
+
+inline r_size_t count() {
+    r_size_t n = 0;
+    for (chunk* c = head_chunk(); c != nullptr; c = c->next) {
+        n += (c->capacity - c->free_count);
+    }
+    return n;
 }
 
 inline void print() {
-    SEXP list = get();
-    for (SEXP cell = list; cell != R_NilValue; cell = CDR(cell)) {
-        REprintf("%p CAR: %p CDR: %p TAG: %p\n", reinterpret_cast<void*>(cell),
-                    reinterpret_cast<void*>(CAR(cell)), reinterpret_cast<void*>(CDR(cell)),
-                    reinterpret_cast<void*>(TAG(cell)));
+    REprintf("vec_store:\n");
+    int idx = 0;
+    for (chunk* c = head_chunk(); c != nullptr; c = c->next, ++idx) {
+        REprintf("  chunk %d: vec=%p capacity=%d in_use=%d\n",
+                 idx, reinterpret_cast<void*>(c->vec),
+                 c->capacity, c->capacity - c->free_count);
     }
     REprintf("---\n");
 }
 
-} // namespace store
+} // namespace vec_store
+
+// ---------------------------------------------------------------------------
+// Refcounted protection tokens.
+//
+// A `protect_cell` is a tiny C++ control block that owns one slot in the
+// chunked VECSXP pool above. Multiple r_sexp wrappers can share the same
+// protect_cell via refcounting -- copy construction just bumps `refs`
+// instead of taking a new pool slot.
+//
+// `protect_cell` instances themselves are recycled from a C++-side freelist,
+// so in the steady state there is zero heap allocation on either the R side
+// (slots come from an existing chunk) or the C++ side.
+// ---------------------------------------------------------------------------
+
+namespace refcount {
+
+struct protect_cell {
+    vec_store::slot_ref token; // slot in the chunked VECSXP pool
+    std::uint32_t       refs;  // how many r_sexps point at this control block
+    protect_cell*       next;  // freelist link (only valid while on freelist)
+};
+
+// C++-side freelist of recycled protect_cell instances. Not thread-safe,
+// but R itself is single-threaded.
+inline protect_cell*& free_list() {
+    static protect_cell* head = nullptr;
+    return head;
+}
+
+inline protect_cell* alloc_cell() {
+    protect_cell*& head = free_list();
+    if (head != nullptr) {
+        protect_cell* p = head;
+        head = p->next;
+        return p;
+    }
+    return new protect_cell{};
+}
+
+inline void free_cell(protect_cell* p) {
+    protect_cell*& head = free_list();
+    p->next = head;
+    head = p;
+}
+
+// Create a new protection token for `x`. Returns nullptr for R_NilValue.
+inline protect_cell* insert(SEXP x) {
+    if (x == R_NilValue) {
+        return nullptr;
+    }
+    protect_cell* p = alloc_cell();
+    p->token = vec_store::insert(x);
+    p->refs  = 1;
+    p->next  = nullptr;
+    return p;
+}
+
+// Bump the refcount. Safe to call with nullptr.
+inline void incref(protect_cell* p) noexcept {
+    if (p != nullptr) {
+        ++p->refs;
+    }
+}
+
+// Drop a reference. When the count hits zero, release the pool slot and
+// recycle the control block.
+inline void decref(protect_cell* p) noexcept {
+    if (p != nullptr && --p->refs == 0) {
+        vec_store::release(p->token);
+        free_cell(p);
+    }
+}
+
+} // namespace refcount
 } // namespace detail
 
 } // namespace cpp20

--- a/inst/include/cpp20/r_sexp.h
+++ b/inst/include/cpp20/r_sexp.h
@@ -12,12 +12,9 @@ namespace internal {
 struct view_tag {};
 }
 
-// General SEXP, reserved for everything except CHARSXP and SYMSXP
-// Wrapper around cpp11::sexp to benefit from automatic protection (cpp11-managed linked list)
+// General SEXP, automatic protection handled via cpp20-managed vector list
 //
-//
-// ----- All credits go to cpp11 authors/maintainers for `cpp11::sexp` -----
-//
+// ----- All credits go to cpp11 authors/maintainers for inspiration from `cpp11::sexp` -----
 //
 
 struct r_sexp {
@@ -29,46 +26,49 @@ struct r_sexp {
 
   private:
 
-  SEXP preserve_token_ = R_NilValue;
+  // Refcounted protection token. nullptr means "view mode" (no protection).
+  // Copy construction bumps `ctl_->refs` instead of allocating a new cons cell,
+  // so passing r_sexp around by value is essentially free
+  detail::refcount::protect_cell* ctl_ = nullptr;
 
-  public: 
+  public:
 
   r_sexp() = default;
-  explicit r_sexp(SEXP data) : value(data), preserve_token_(detail::store::insert(value)) {}
+  explicit r_sexp(SEXP data) : value(data), ctl_(detail::refcount::insert(data)) {}
 
-  // We maintain our own new `preserve_token_`
-  r_sexp(const r_sexp& rhs) : value(rhs.value), preserve_token_(detail::store::insert(rhs.value)) {}
-
-  // We take ownership over the `rhs.preserve_token_`.
-  // Importantly we clear it in the `rhs` so it can't release the object upon destruction.
-  r_sexp(r_sexp&& rhs) noexcept : value(rhs.value), preserve_token_(rhs.preserve_token_) {
-    rhs.value = R_NilValue;
-    rhs.preserve_token_ = R_NilValue;
+  // Copy = refcount bump (no R API involvement)
+  r_sexp(const r_sexp& rhs) noexcept : value(rhs.value), ctl_(rhs.ctl_) {
+    detail::refcount::incref(ctl_);
   }
 
-  r_sexp& operator=(const r_sexp& rhs) {
+  // Move = steal the token, leaving rhs empty
+  r_sexp(r_sexp&& rhs) noexcept : value(rhs.value), ctl_(rhs.ctl_) {
+    rhs.value = R_NilValue;
+    rhs.ctl_ = nullptr;
+  }
+
+  r_sexp& operator=(const r_sexp& rhs) noexcept {
     if (this != &rhs) {
-        SEXP new_token = detail::store::insert(rhs.value); // insert first
-        detail::store::release(preserve_token_);           // then release old
+        detail::refcount::incref(rhs.ctl_); // bump new first, release old after
+        detail::refcount::decref(ctl_);
         value = rhs.value;
-        preserve_token_ = new_token;
+        ctl_ = rhs.ctl_;
     }
     return *this;
-}
+  }
 
   r_sexp& operator=(r_sexp&& rhs) noexcept {
-    detail::store::release(preserve_token_);
-    value = rhs.value;
-    
-    // Steal the token, do not create a new one
-    preserve_token_ = rhs.preserve_token_;
-    
-    rhs.value = R_NilValue;
-    rhs.preserve_token_ = R_NilValue;
+    if (this != &rhs) {
+      detail::refcount::decref(ctl_);
+      value = rhs.value;
+      ctl_ = rhs.ctl_;
+      rhs.value = R_NilValue;
+      rhs.ctl_ = nullptr;
+    }
     return *this;
   }
 
-  ~r_sexp() { detail::store::release(preserve_token_); }
+  ~r_sexp() { detail::refcount::decref(ctl_); }
 
   // Implicit conversion to SEXP
   operator SEXP() const noexcept { return value; }
@@ -76,7 +76,7 @@ struct r_sexp {
 
   // Optimized constructor
   // convert SEXP -> r_sexp directly without extra protection
-  explicit r_sexp(SEXP s, internal::view_tag) : value(s), preserve_token_(R_NilValue) {}
+  explicit r_sexp(SEXP s, internal::view_tag) noexcept : value(s), ctl_(nullptr) {}
 
   r_size_t length() const noexcept {
     return Rf_xlength(value);


### PR DESCRIPTION
This PR brings in a new automatic protection system via chains of protected vector lists (VECSXP). 

It replaces the cons-cell linked-list protection store with a chunked VECSXP pool plus a refcounted token layer. Protections now come from pre-allocated slots in shared vectors rather than one R-side allocation per object. Copies of the same r_sexp object share a single slot instead of taking a new one, improving copy-overhead.