### PR TITLE
Apply consistent zero-indexing

### DIFF
--- a/R/cpp20.R
+++ b/R/cpp20.R
@@ -368,8 +368,8 @@ test_var <- function(x, na_rm) {
   .Call(`_cpp20_test_var`, x, na_rm)
 }
 
-test_subset <- function(x, i) {
-  .Call(`_cpp20_test_subset`, x, i)
+test_subset <- function(x, i, invert) {
+  .Call(`_cpp20_test_subset`, x, i, invert)
 }
 
 test_fill <- function(x, where, with) {

--- a/README.Rmd
+++ b/README.Rmd
@@ -59,7 +59,7 @@ The benefit of this is that when registering C++ functions to R, inputs can be s
 
 ### Vector indexing
 
-Most indexing is 0-based except when dealing with vectors of indices, which are 1-indexed. 1-indexed indices are used in `subset()`, `find()`, and other functions which accept or return a vector of indices.
+All indexing is 0-based including subsetting vectors.
 
 ### 64-bit integers
 

--- a/README.md
+++ b/README.md
@@ -91,9 +91,7 @@ we would need to be strict with inputs to balance things out.
 
 ### Vector indexing
 
-Most indexing is 0-based except when dealing with vectors of indices,
-which are 1-indexed. 1-indexed indices are used in `subset()`, `find()`,
-and other functions which accept or return a vector of indices.
+All indexing is 0-based including subsetting vectors.
 
 ### 64-bit integers
 

--- a/inst/include/cpp20/r_df.h
+++ b/inst/include/cpp20/r_df.h
@@ -185,9 +185,6 @@ struct r_df {
     void set_colnames(const r_vec<U>& colnames) {
         value.set_names(colnames);
     }
-
-    // IMPORTANT - indices are 1-indexed
-    // This has the benefit of allowing empty locations (0) and negative indexing
     template <internal::RSubscript U>
     r_df subset(const r_vec<U>& indices) const {
         if (ncol() == 0){

--- a/inst/include/cpp20/r_vec.h
+++ b/inst/include/cpp20/r_vec.h
@@ -190,10 +190,10 @@ struct r_vec {
   }
 
   template <internal::RSubscript U> 
-  r_vec<T> subset(const r_vec<U>& indices, bool check = true) const;
+  r_vec<T> subset(const r_vec<U>& indices, bool check = true, bool invert = false) const;
 
-  r_vec<T> subset(r_size_t index, bool check = true) const {
-    return subset(r_vec<r_int64>(1, r_int64(static_cast<int64_t>(index))), check);
+  r_vec<T> subset(r_size_t index, bool check = true, bool invert = false) const {
+    return subset(r_vec<r_int64>(1, r_int64(static_cast<int64_t>(index))), check, invert);
   }
 
   r_vec<r_str_view> names() const {

--- a/inst/include/cpp20/r_vec.h
+++ b/inst/include/cpp20/r_vec.h
@@ -189,8 +189,6 @@ struct r_vec {
       }
   }
 
-  // IMPORTANT - indices are 1-indexed
-  // This has the benefit of allowing empty locations (0) and negative indexing
   template <internal::RSubscript U> 
   r_vec<T> subset(const r_vec<U>& indices, bool check = true) const;
 
@@ -348,7 +346,7 @@ struct r_vec {
     }
   }
 
-  // 1-indexed locations of value in vector
+  // locations of value in vector
   template <internal::RNumericSubscript V = r_int>
   r_vec<V> find(T const& value, bool invert = false) const {
 
@@ -370,7 +368,7 @@ struct r_vec {
       int_t out_size = n - n_vals;
       r_vec<V> out(out_size);
       while (whichi < out_size){
-          out.set(whichi, V(i + 1));
+          out.set(whichi, V(i));
           whichi += static_cast<int_t>(!identical(view(i++), value));
       }
       return out;
@@ -378,7 +376,7 @@ struct r_vec {
       int_t out_size = n_vals;
       r_vec<V> out(out_size);
       while (whichi < out_size){
-        out.set(whichi, V(i + 1));
+        out.set(whichi, V(i));
         whichi += static_cast<int_t>(identical(view(i++), value));
     }
     return out;

--- a/inst/include/cpp20/sugar/r_groups.h
+++ b/inst/include/cpp20/sugar/r_groups.h
@@ -21,7 +21,7 @@ struct groups {
   // Manual constructor
   explicit groups(r_vec<r_int> x, int ngroups, bool groups_sorted) : ids(std::move(x)), n_groups(ngroups), sorted(groups_sorted) {}
 
-  // 1-indexed group start locations
+  // group start locations
   r_vec<r_int> starts() const {
 
     int n = ids.length();
@@ -41,12 +41,12 @@ struct groups {
         int* RESTRICT p_out = out.data();
 
         curr_group = 0;
-        p_out[0] = 1;
+        p_out[0] = 0;
         
         for (int i = 1; i < n; ++i){
             // New group
             if (p_ids[i] > curr_group){
-                p_out[++curr_group] = (i + 1);
+                p_out[++curr_group] = i;
             }
             //
             // if (p_ids[i] > p_ids[i - 1]){
@@ -68,12 +68,9 @@ struct groups {
             p_out[curr_group] = std::min(p_out[curr_group], i);
           }
 
-          // Make 1-indexed start indices
           for (int i = 0; i < n_groups; ++i){
-            if (p_out[i] == unwrap(r_limits<r_int>::max())){
-                p_out[i] = 0; // This can happen with unused factor levels for example
-            } else {
-                ++p_out[i];
+            if (p_out[i] == unwrap(r_limits<r_int>::max())) [[unlikely]] {
+                p_out[i] = unwrap(na<r_int>()); // This can happen with unused factor levels for example
             }
           }
     

--- a/inst/include/cpp20/sugar/r_match.h
+++ b/inst/include/cpp20/sugar/r_match.h
@@ -7,7 +7,7 @@
 
 namespace cpp20 {
 
-// 1-indexed match locations
+// match locations
 template <internal::RNumericSubscript U = r_int, RVal T>
 r_vec<U> match(const r_vec<T>& needles, const r_vec<T>& haystack) {
 
@@ -33,7 +33,7 @@ r_vec<U> match(const r_vec<T>& needles, const r_vec<T>& haystack) {
     auto val = needles.view(0);
     for (r_size_t i = 0; i < n_haystack; ++i){
       if (identical(val, haystack.view(i))){
-        out.set(0, U(static_cast<unwrap_t<U>>(i + 1)));
+        out.set(0, U(static_cast<unwrap_t<U>>(i)));
         return out;
       }
     }
@@ -68,7 +68,7 @@ r_vec<U> match(const r_vec<T>& needles, const r_vec<T>& haystack) {
         if (!is_na(val)){
           size_t idx = static_cast<size_t>(static_cast<int64_t>(val) - min_val);
           if (is_na(p_table[idx])){
-            p_table[idx] = static_cast<int>(i) + 1;
+            p_table[idx] = static_cast<int>(i);
           }
         }
       }
@@ -77,7 +77,7 @@ r_vec<U> match(const r_vec<T>& needles, const r_vec<T>& haystack) {
       int na_pos = na<r_int>();
       for (r_size_t i = 0; i < n_haystack; ++i) {
         if (is_na(p_haystack[i])){
-          na_pos = static_cast<int>(i) + 1;
+          na_pos = static_cast<int>(i);
           break;
         }
       }
@@ -104,7 +104,7 @@ r_vec<U> match(const r_vec<T>& needles, const r_vec<T>& haystack) {
   lookup.reserve(internal::get_hash_map_reserve_size<T>(n_haystack));
 
   for (r_size_t i = 0; i < n_haystack; ++i) {
-    lookup.try_emplace(p_haystack[i], int_t(i) + int_t(1));
+    lookup.try_emplace(p_haystack[i], int_t(i));
   }
 
   // Match needles

--- a/inst/include/cpp20/sugar/r_subset.h
+++ b/inst/include/cpp20/sugar/r_subset.h
@@ -154,25 +154,24 @@ inline r_vec<T> r_vec<T>::subset(const r_vec<U>& indices, bool check) const {
     r_vec<T> out(n);
 
     if (check){
-      r_size_t xn = length(), k = 0;
+      r_size_t xn = length();
       unsigned_int_t na_val = unwrap(na<U>());
       unsigned_int_t j;
   
       for (r_size_t i = 0; i < n; ++i){
         j = unwrap(indices.get(i));
         if (static_cast<r_size_t>(j) < xn){
-          out.set(k++, view(static_cast<r_size_t>(j)));
+          out.set(i, view(static_cast<r_size_t>(j)));
         } else if (j > na_val){
           // If j > n_val then it is a negative signed integer
           abort("Negative indices are unsupported, use `invert = true`");
         } else {
           if constexpr (RScalar<T>){
-            out.set(k++, na<T>());
+            out.set(i, na<T>());
           }
         }
       }
-  
-      return out.resize(k);
+      return out;
     } else {
       for (r_size_t i = 0; i < n; ++i){
         out.set(i, view(unwrap(indices.get(i))));

--- a/inst/include/cpp20/sugar/r_subset.h
+++ b/inst/include/cpp20/sugar/r_subset.h
@@ -134,7 +134,7 @@ r_vec<V> clean_locs(const r_vec<U>& locs, const r_vec<T>& x){
 
 template <RVal T>
 template <internal::RSubscript U>
-inline r_vec<T> r_vec<T>::subset(const r_vec<U>& indices, bool check) const {
+inline r_vec<T> r_vec<T>::subset(const r_vec<U>& indices, bool check, bool invert) const {
 
   if (indices.is_null()){
     return *this;
@@ -142,11 +142,19 @@ inline r_vec<T> r_vec<T>::subset(const r_vec<U>& indices, bool check) const {
 
   if constexpr (RLogicalType<U> || RStringType<U>){
     if (is_long()){
-      return subset(internal::clean_locs<r_int64>(indices, *this), /*check=*/ false);
+      return subset(internal::clean_locs<r_int64>(indices, *this), /*check=*/ false, /*invert=*/ invert);
     } else {
-      return subset(internal::clean_locs<r_int>(indices, *this), /*check=*/ false);
+      return subset(internal::clean_locs<r_int>(indices, *this), /*check=*/ false, /*invert=*/ invert);
     }
   } else {
+
+    if (invert){
+      if (is_long()){
+        return subset(internal::exclude_locs<r_int64>(indices, length()), false, false);
+      } else {
+        return subset(internal::exclude_locs<r_int>(indices, length()), false, false);
+      }
+    }
 
     using unsigned_int_t = std::make_unsigned_t<unwrap_t<U>>;
     r_size_t n = indices.length();

--- a/inst/include/cpp20/sugar/r_subset.h
+++ b/inst/include/cpp20/sugar/r_subset.h
@@ -30,32 +30,33 @@ r_vec<V> exclude_locs(const r_vec<U>& exclude, r_size_t xn) {
   r_size_t i = 0, k = 0;
 
   // Which elements do we keep?
-  std::vector<uint8_t> keep(xn, uint8_t(1));
+  std::vector<uint8_t> keep(xn, 1U);
 
   for (r_size_t j = 0; j < m; ++j) {
     if (is_na(exclude.get(j))) continue;
-    if (exclude.get(j) > 0) [[unlikely]] {
-      abort("Cannot mix positive and negative subscripts");
+    if (exclude.get(j) < 0) [[unlikely]] {
+      abort("Please supply positive indices to %s", __func__);
     }
-    idx = -unwrap(exclude.get(j));
+    idx = unwrap(exclude.get(j));
     // Check keep array for already assigned FALSE to avoid double counting
-    if (idx > 0 && idx <= n && keep[idx - 1] == 1U){
-      keep[idx - 1] = 0U;
+    if (idx < n && keep[idx] == 1U){
+      keep[idx] = 0U;
       ++exclude_count;
     }
   }
   out_size = n - exclude_count;
   r_vec<V> out(out_size);
 
-  while(k != out_size){
-    if (keep[i++] == 1U){
+  while (k != out_size){
+    if (keep[i] == 1U){
       out.set(k++, V(static_cast<unwrap_t<V>>(i)));
     }
+    ++i;
   }
   return out;
 }
 
-// Returns valid 1-indexed indices
+// Returns valid indices
 // It ignores NA and out-of-bounds (OOB) indices, which differs to subset() which returns NA when given NA or OOB
 template <internal::RNumericSubscript V = r_int, typename T, internal::RSubscript U>
 r_vec<V> clean_locs(const r_vec<U>& locs, const r_vec<T>& x){
@@ -90,38 +91,37 @@ r_vec<V> clean_locs(const r_vec<U>& locs, const r_vec<T>& x){
     }
     return locs.template find<V>(r_true, false);
   } else {
-    r_size_t zero_count = 0,
-    pos_count = 0,
+    r_size_t pos_count = 0,
     oob_count = 0,
     na_count = 0,
     neg_count = 0;
 
   for (r_size_t i = 0; i < n; ++i){
     auto loc = unwrap(locs.get(i));
-    zero_count += (loc == 0);
-    pos_count += (loc > 0);
-    na_count += is_na(loc);
-    oob_count += !is_na(loc) && std::abs(loc) > xn;
-  }
-
-  neg_count = n - pos_count - zero_count - na_count;
-
-  if ( (pos_count > 0 && neg_count > 0) ||
-       (neg_count > 0 && na_count > 0)){
-    abort("Cannot mix positive and negative indices");
+    if (is_na(loc)){
+      ++na_count;
+    } else if (loc < 0){
+      ++neg_count;
+    } else {
+      ++pos_count;
+      if (static_cast<r_size_t>(loc) >= xn){
+        ++oob_count;
+      }
+    }
   }
 
   if (neg_count > 0){
-    return internal::exclude_locs<V>(locs, xn);
+    abort("Negative indices are not allowed, use `invert = true`");
   }
-  if (zero_count > 0 || oob_count > 0 || na_count > 0){
+  if (oob_count > 0 || na_count > 0){
     r_size_t out_size = pos_count - oob_count;
     r_vec<V> out(out_size);
 
     r_size_t k = 0;
     for (r_size_t i = 0; i < n; ++i){
-      if (internal::between_impl<r_size_t>(unwrap(locs.get(i)), r_size_t(1), xn)){
-        out.set(k++, V(static_cast<unwrap_t<V>>(unwrap(locs.get(i)))));
+      auto loc = unwrap(locs.get(i));
+      if (!is_na(loc) && loc >= 0 && static_cast<r_size_t>(loc) < xn){
+        out.set(k++, V(static_cast<unwrap_t<V>>(loc)));
       }
     }
     return out;
@@ -160,18 +160,12 @@ inline r_vec<T> r_vec<T>::subset(const r_vec<U>& indices, bool check) const {
   
       for (r_size_t i = 0; i < n; ++i){
         j = unwrap(indices.get(i));
-        if (j >= 1U && static_cast<r_size_t>(j) <= xn){
-          out.set(k++, view(static_cast<r_size_t>(j) - r_size_t(1)));
-        } 
-        // If j > n_val then it is a negative signed integer
-        else if (j > na_val){
-          if (is_long()){
-            return subset(internal::exclude_locs<r_int64>(indices, xn));
-          } else {
-            return subset(internal::exclude_locs<r_int>(indices, xn));
-          }
-        } 
-        else if (j != 0U){
+        if (static_cast<r_size_t>(j) < xn){
+          out.set(k++, view(static_cast<r_size_t>(j)));
+        } else if (j > na_val){
+          // If j > n_val then it is a negative signed integer
+          abort("Negative indices are unsupported, use `invert = true`");
+        } else {
           if constexpr (RScalar<T>){
             out.set(k++, na<T>());
           }
@@ -181,7 +175,7 @@ inline r_vec<T> r_vec<T>::subset(const r_vec<U>& indices, bool check) const {
       return out.resize(k);
     } else {
       for (r_size_t i = 0; i < n; ++i){
-        out.set(i, view(unwrap(indices.get(i)) - 1));
+        out.set(i, view(unwrap(indices.get(i))));
     }
     return out;
   }
@@ -236,7 +230,7 @@ r_vec<V> r_vec<T>::find(const r_vec<T>& values, bool invert) const {
       r_size_t n = length();
       r_vec<V> out(n);
       OMP_SIMD
-      for (r_size_t i = 0; i < n; ++i) out.set(i, V(static_cast<unwrap_t<V>>(i + 1)));
+      for (r_size_t i = 0; i < n; ++i) out.set(i, V(static_cast<unwrap_t<V>>(i)));
       return out;
     } else {
       return r_vec<V>();
@@ -281,7 +275,7 @@ void r_vec<T>::fill(const r_vec<U>& where, const r_vec<T>& with) {
     r_size_t where_size = where_clean.length();
   
     for (r_size_t i = 0; i < where_size; recycle_index(withi, with_size), ++i){
-      set(unwrap(where_clean.get(i)) - 1, with_clean.get(withi));
+      set(unwrap(where_clean.get(i)), with_clean.get(withi));
     }
   } else {
     // Clean where vector
@@ -289,7 +283,7 @@ void r_vec<T>::fill(const r_vec<U>& where, const r_vec<T>& with) {
     r_size_t where_size = where_clean.length();
   
     for (r_size_t i = 0; i < where_size; recycle_index(withi, with_size), ++i){
-      set(unwrap(where_clean.get(i)) - 1, with_clean.get(withi));
+      set(unwrap(where_clean.get(i)), with_clean.get(withi));
     }
   }
 }
@@ -323,79 +317,6 @@ void r_vec<T>::replace(const r_vec<T>& old_values, const r_vec<T>& new_values){
       }
   }
 }
-
-// 0-indexed negative locations (can't do "everything but first location" with this approach)
-// template <typename U>
-// requires (any<U, r_int, r_int64>)
-// r_vec<U> exclude_locs(const r_vec<U>& exclude, unwrap_t<U> xn) {
-
-//   using int_t = unwrap_t<U>;
-
-//   int_t n = xn;
-//   int_t m = exclude.length();
-//   int_t out_size, idx;
-//   int_t exclude_count = 0;
-//   int_t i = 0, k = 0;
-
-//   // Which elements do we keep?
-//   std::vector<bool> keep(n, true);
-
-//   for (int_t j = 0; j < m; ++j) {
-//     if (is_na(exclude.get(j))) continue;
-//     if (exclude.get(j) > 0){
-//       abort("Cannot mix positive and negative subscripts");
-//     }
-//     idx = -exclude.get(j);
-//     // Check keep array for already assigned FALSE to avoid double counting
-//     if (idx < n && keep[idx]){
-//       keep[idx] = false;
-//       ++exclude_count;
-//     }
-//   }
-//   out_size = n - exclude_count;
-//   auto out = r_vec<r_int>(out_size);
-
-//   while(k != out_size){
-//     if (keep[i++]){
-//       out.set(k++, i - 1);
-//     }
-//   }
-//   return out;
-// }
-
-// // 0-indexed indices
-// template <RVal T>
-// template <typename U>
-// requires (any<U, r_int, r_int64>)
-// inline r_vec<T> r_vec<T>::subset(const r_vec<U>& indices) const {
-
-//   using unsigned_int_t = std::make_unsigned_t<unwrap_t<U>>;
-
-//   unsigned_int_t
-//   xn = length(),
-//     n = indices.length(),
-//     k = 0,
-//     na_val = unwrap(na<U>()),
-//     j;
-
-//   auto out = r_vec<T>(n);
-
-//   for (unsigned_int_t i = 0; i < n; ++i){
-//     j = unwrap(indices.get(i));
-//     if (j < xn){
-//       out.set(k++, get(j));
-//     } 
-//     // If j > n_val then it is a negative signed integer
-//     else if (j > na_val){
-//       return subset(exclude_locs(indices, xn));
-//     } 
-//     else {
-//       out.set(k++, na<T>());
-//     }
-//   }
-//   return out.resize(k);
-// }
-
 
 }
 

--- a/src/cpp20.cpp
+++ b/src/cpp20.cpp
@@ -841,13 +841,13 @@ extern "C" SEXP _cpp20_test_var(SEXP x, SEXP na_rm) {
   END_CPP20
 }
 // test_subset.h
-extern "C" SEXP _cpp20_test_subset(SEXP x, SEXP i) {
+extern "C" SEXP _cpp20_test_subset(SEXP x, SEXP i, SEXP invert) {
   BEGIN_CPP20
-  return dispatch_template_impl<2, 2, std::array<int, 2>{0, 1}>(
-    []<typename T, typename U>(SEXP x_internal, SEXP i_internal) -> decltype(cpp_to_sexp(test_subset(as<T>(x_internal), as<r_vec<U>>(i_internal)))) {
-        return cpp_to_sexp(test_subset(as<T>(x_internal), as<r_vec<U>>(i_internal)));
+  return dispatch_template_impl<2, 3, std::array<int, 3>{0, 1, -1}>(
+    []<typename T, typename U>(SEXP x_internal, SEXP i_internal, SEXP invert_internal) -> decltype(cpp_to_sexp(test_subset(as<T>(x_internal), as<r_vec<U>>(i_internal), as<bool>(invert_internal)))) {
+        return cpp_to_sexp(test_subset(as<T>(x_internal), as<r_vec<U>>(i_internal), as<bool>(invert_internal)));
     },
-    x, i
+    x, i, invert
   );
   END_CPP20
 }
@@ -997,7 +997,7 @@ static const R_CallMethodDef CallEntries[] = {
     {"_cpp20_test_str2",                          (DL_FUNC) &_cpp20_test_str2,                          1},
     {"_cpp20_test_str3",                          (DL_FUNC) &_cpp20_test_str3,                          1},
     {"_cpp20_test_str4",                          (DL_FUNC) &_cpp20_test_str4,                          1},
-    {"_cpp20_test_subset",                        (DL_FUNC) &_cpp20_test_subset,                        2},
+    {"_cpp20_test_subset",                        (DL_FUNC) &_cpp20_test_subset,                        3},
     {"_cpp20_test_sum",                           (DL_FUNC) &_cpp20_test_sum,                           2},
     {"_cpp20_test_sym",                           (DL_FUNC) &_cpp20_test_sym,                           1},
     {"_cpp20_test_template_null",                 (DL_FUNC) &_cpp20_test_template_null,                 1},

--- a/src/test_sort.h
+++ b/src/test_sort.h
@@ -20,7 +20,6 @@ requires ((RVector<T> && RSortableType<typename T::data_type>) || RFactor<T>)
 [[cpp20::register]]
 T test_sort(T x, bool preserve_ties){
   auto o = test_order(x, preserve_ties);
-  o += 1;
   return x.subset(o);
 }
 

--- a/src/test_subset.h
+++ b/src/test_subset.h
@@ -6,8 +6,8 @@ using namespace cpp20;
 template <RVector T, typename U>
 requires (any<U, r_int, r_lgl, r_str, r_str_view>)
 [[cpp20::register]]
-T test_subset(T x, r_vec<U> i){
-    return x.subset(i);
+T test_subset(T x, r_vec<U> i, bool invert){
+    return x.subset(i, true, invert);
 }
 
 template <RVal T, RVal U>

--- a/tests/testthat/test-which.R
+++ b/tests/testthat/test-which.R
@@ -1,5 +1,5 @@
 test_that("which", {
   x <- c(TRUE, NA, TRUE, TRUE, FALSE, FALSE, NA, NA, TRUE, NA)
-  expect_identical(test_find(x, TRUE), which(x))
-  expect_identical(setdiff(seq_along(x), test_find(x, TRUE)), which(!x %in% TRUE))
+  expect_identical(test_find(x, TRUE) + 1L, which(x))
+  expect_identical(setdiff(seq_along(x), test_find(x, TRUE) + 1L), which(!x %in% TRUE))
 })


### PR DESCRIPTION
For consistency, all indexing is 0-indexed. This means one can no longer subset using negative indices and that subsetting with a zero index (via `subset()`) returns the first vector element instead of a zero-length vector (like in R).