### PR TITLE
Lazy symbols

### DIFF
--- a/inst/include/cpp20/r_attrs.h
+++ b/inst/include/cpp20/r_attrs.h
@@ -86,7 +86,7 @@ template <RObject T>
 inline r_vec<r_sexp> get_attrs(const T& x) {
   if (can_have_attributes(x) && has_attrs(x)){
     SEXP x_ = x;
-    SEXP expr = Rf_protect(Rf_lang2(cpp20::internal::lazy_load_symbol(cpp20::internal::attrs_sym, "attributes"), x_));
+    SEXP expr = Rf_protect(Rf_lang2(cpp20::internal::lazy_sym<"attributes">(), x_));
     SEXP res = Rf_protect(Rf_eval(expr, R_BaseEnv));
     r_vec<r_sexp> out(res);
     Rf_unprotect(2);

--- a/inst/include/cpp20/r_attrs.h
+++ b/inst/include/cpp20/r_attrs.h
@@ -86,7 +86,7 @@ template <RObject T>
 inline r_vec<r_sexp> get_attrs(const T& x) {
   if (can_have_attributes(x) && has_attrs(x)){
     SEXP x_ = x;
-    SEXP expr = Rf_protect(Rf_lang2(cpp20::internal::lazy_sym<"attributes">(), x_));
+    SEXP expr = Rf_protect(Rf_lang2(cpp20::lazy_sym<"attributes">(), x_));
     SEXP res = Rf_protect(Rf_eval(expr, R_BaseEnv));
     r_vec<r_sexp> out(res);
     Rf_unprotect(2);

--- a/inst/include/cpp20/r_sym.h
+++ b/inst/include/cpp20/r_sym.h
@@ -20,7 +20,7 @@ struct sym_name {
 
 // Meyers-singleton method to cache R symbols
 template <sym_name name>
-inline SEXP lazy_sym() {
+inline SEXP lazy_sym_impl() {
     static SEXP s = Rf_installChar(Rf_mkCharCE(name.data, CE_UTF8));
     return s;
 }
@@ -31,7 +31,7 @@ struct r_sym {
   SEXP value;
   using value_type = r_sexp;
 
-  r_sym() : value(internal::lazy_sym<"NA">()){}
+  r_sym() : value(internal::lazy_sym_impl<"NA">()){}
   explicit r_sym(SEXP x) : value{x} {
     internal::check_valid_construction<r_sym>(value);
   }
@@ -39,10 +39,15 @@ struct r_sym {
     internal::check_valid_construction<r_sym>(value);
   }
   explicit r_sym(const char *x) : value(Rf_installChar(Rf_mkCharCE(x, CE_UTF8))) {}
-  explicit r_sym(const r_str_view& x) : value(x.value == NA_STRING ? internal::lazy_sym<"NA">() : Rf_installChar(x.value)){}
+  explicit r_sym(const r_str_view& x) : value(x.value == NA_STRING ? internal::lazy_sym_impl<"NA">() : Rf_installChar(x.value)){}
   explicit r_sym(const r_str& x) : r_sym(r_str_view(x)){}
   operator SEXP() const noexcept { return value; }
 };
+
+template <internal::sym_name name>
+inline r_sym lazy_sym() {
+    return r_sym(internal::lazy_sym_impl<name>());
+}
 
 namespace symbol {
 

--- a/inst/include/cpp20/r_sym.h
+++ b/inst/include/cpp20/r_sym.h
@@ -10,9 +10,19 @@
 namespace cpp20 {
 
 namespace internal {
-inline SEXP na_sym = NULL;
-inline SEXP lazy_load_symbol(SEXP null_or_symbol, const char* name){
-    return null_or_symbol == NULL ? Rf_installChar(Rf_mkCharCE(name, CE_UTF8)) : null_or_symbol;
+template <std::size_t N>
+struct sym_name {
+    char data[N];
+    constexpr sym_name(const char (&s)[N]) {
+      for (std::size_t i = 0; i < N; ++i) data[i] = s[i];
+    }
+};
+
+// Meyers-singleton method to cache R symbols
+template <sym_name name>
+inline SEXP lazy_sym() {
+    static SEXP s = Rf_installChar(Rf_mkCharCE(name.data, CE_UTF8));
+    return s;
 }
 }
 
@@ -21,7 +31,7 @@ struct r_sym {
   SEXP value;
   using value_type = r_sexp;
 
-  r_sym() : value(internal::lazy_load_symbol(internal::na_sym, "NA")){}
+  r_sym() : value(internal::lazy_sym<"NA">()){}
   explicit r_sym(SEXP x) : value{x} {
     internal::check_valid_construction<r_sym>(value);
   }
@@ -29,7 +39,7 @@ struct r_sym {
     internal::check_valid_construction<r_sym>(value);
   }
   explicit r_sym(const char *x) : value(Rf_installChar(Rf_mkCharCE(x, CE_UTF8))) {}
-  explicit r_sym(const r_str_view& x) : value(Rf_installChar(x.value == NA_STRING ? internal::lazy_load_symbol(internal::na_sym, "NA") : x.value)){}
+  explicit r_sym(const r_str_view& x) : value(x.value == NA_STRING ? internal::lazy_sym<"NA">() : Rf_installChar(x.value)){}
   explicit r_sym(const r_str& x) : r_sym(r_str_view(x)){}
   operator SEXP() const noexcept { return value; }
 };

--- a/inst/include/cpp20/r_vec.h
+++ b/inst/include/cpp20/r_vec.h
@@ -492,7 +492,7 @@ struct r_vec {
 
   // POSIXct-only members
   r_str tzone() const requires RPsxctType<T> {
-    auto tz = r_vec<r_str_view>(Rf_getAttrib(sexp, r_sym("tzone")));
+    auto tz = r_vec<r_str_view>(Rf_getAttrib(sexp, lazy_sym<"tzone">()));
     
     if (tz.length() == 0){
       abort("`r_vec<r_psxct_t>` vector must have a valid tzone attribute");
@@ -506,7 +506,7 @@ struct r_vec {
   }
 
   void set_tzone(const char* tz) requires RPsxctType<T> {
-    Rf_setAttrib(sexp, r_sym("tzone"), r_vec<r_str>(1, r_str(tz)));
+    Rf_setAttrib(sexp, lazy_sym<"tzone">(), r_vec<r_str>(1, r_str(tz)));
   }
 
   // list-only members

--- a/inst/include/cpp20/r_vec_utils.h
+++ b/inst/include/cpp20/r_vec_utils.h
@@ -103,7 +103,7 @@ inline r_sexp new_vec_impl(r_size_t n) {
     SET_STRING_ELT(cls, 0, Rf_mkCharCE("POSIXct", CE_UTF8));
     SET_STRING_ELT(cls, 1, Rf_mkCharCE("POSIXt", CE_UTF8));
     Rf_setAttrib(out, symbol::class_sym, cls);
-    Rf_setAttrib(out, r_sym("tzone"), Rf_ScalarString(Rf_mkCharCE("UTC", CE_UTF8)));
+    Rf_setAttrib(out, lazy_sym<"tzone">()), Rf_ScalarString(Rf_mkCharCE("UTC", CE_UTF8)));
     return out;
   } else {
     static_assert(
@@ -166,7 +166,7 @@ inline r_sexp new_scalar_vec(T const& default_value) {
     SET_STRING_ELT(cls, 0, Rf_mkCharCE("POSIXct", CE_UTF8));
     SET_STRING_ELT(cls, 1, Rf_mkCharCE("POSIXt", CE_UTF8));
     Rf_setAttrib(out, symbol::class_sym, cls);
-    Rf_setAttrib(out, r_sym("tzone"), Rf_ScalarString(r_str("UTC")));
+    Rf_setAttrib(out, lazy_sym<"tzone">(), Rf_ScalarString(r_str("UTC")));
     return out;
   } else {
     static_assert(


### PR DESCRIPTION
Compile-time lazy loading of symbols is now possible. 

**Example**

```cpp
r_sym hi_symbol = lazy_sym<"hi">();
```