### PR TITLE
Fix sourcing template functions

### DIFF
--- a/R/cpp_source.R
+++ b/R/cpp_source.R
@@ -143,6 +143,7 @@ cpp_source <- function(file, code = NULL, env = parent.frame(),
   cpp_functions_definitions <- generate_cpp_functions(funs, package = package)
   cpp_path <- file.path(dirname(new_file_path), "cpp20.cpp")
   brio::write_lines(c("#include <cpp20/r_dispatch.h>",
+                      glue::glue('#include "{new_file_name}"'),
                       "using namespace cpp20;",
                       "using internal::cpp_to_sexp;",
                       "using internal::dispatch_template_impl;",
@@ -157,10 +158,9 @@ cpp_source <- function(file, code = NULL, env = parent.frame(),
                                       use_package = TRUE)
   makevars_content <- generate_makevars(includes, cxx_std, debug)
   brio::write_lines(makevars_content, file.path(new_dir, "Makevars"))
-  source_files <- normalizePath(c(new_file_path, cpp_path),
-                                winslash = "/")
-  res <- callr::rcmd("SHLIB", source_files, user_profile = TRUE,
-                     show = !quiet, wd = new_dir)
+  shared_lib_name <- paste0(tools::file_path_sans_ext(new_file_name), .Platform$dynlib.ext)
+  res <- callr::rcmd("SHLIB", c(cpp_path, "-o", shared_lib_name),
+                     user_profile = TRUE, show = !quiet, wd = new_dir)
   if (res$status != 0) {
     error_messages <- res$stderr
     error_messages <- gsub(tools::file_path_sans_ext(new_file_path),


### PR DESCRIPTION
### Support template functions in `cpp_source()`

Previously, `cpp_source()` compiled the user's .cpp file and the generated temporary cpp20.cpp file as two separate translation units. This worked for ordinary functions but broke for template functions - a template instantiation needs the full definition visible at the call site, and a forward declaration isn't enough.

The generated temporary dispatch file now includes the user's source file directly, and the user's file is no longer compiled as a standalone TU. This makes the template body visible to the dispatcher's lambda, so `dispatch_template_impl` can instantiate it.

While including a .cpp file is unusual, it should be fine here as only ever one TU is created so there is less (or no) risk of duplicate-symbol ODR violations.