### PR TITLE
R sexp methods

### DIFF
--- a/inst/include/cppally.hpp
+++ b/inst/include/cppally.hpp
@@ -53,5 +53,6 @@
 #include <cppally/sugar/r_recycle.h>
 #include <cppally/sugar/r_math.h>
 #include <cppally/sugar/r_seq.h>
+#include <cppally/sugar/r_sexp_methods.h>
 
 #endif

--- a/inst/include/cppally/r_copy.h
+++ b/inst/include/cppally/r_copy.h
@@ -63,16 +63,6 @@ inline r_sym deep_copy(const r_sym& x){
     return x;
 }
 
-template<>
-inline r_sexp deep_copy(const r_sexp& x){
-    return view_sexp(x, [](const auto& vec) -> r_sexp {
-        if constexpr (!is<decltype(vec), r_sexp>){
-            return r_sexp(static_cast<SEXP>(deep_copy(vec)));
-        } else {
-            return r_sexp(safe[Rf_duplicate](vec));
-        }
-    });
-}
 
 template <RVector T>
 T shallow_copy(const T& x){
@@ -106,16 +96,6 @@ inline r_sym shallow_copy(const r_sym& x){
     return x;
 }
 
-template<>
-inline r_sexp shallow_copy(const r_sexp& x){
-    return view_sexp(x, [](const auto& vec) -> r_sexp {
-        if constexpr (!is<decltype(vec), r_sexp>){
-            return r_sexp(static_cast<SEXP>(shallow_copy(vec)));
-        } else {
-            return r_sexp(safe[Rf_shallow_duplicate](vec));
-        }
-    });
-}
 
 }
 #endif

--- a/inst/include/cppally/r_df_methods.h
+++ b/inst/include/cppally/r_df_methods.h
@@ -11,6 +11,7 @@
 #include <cppally/r_list_helpers.h>
 #include <cppally/sugar/r_subset.h>
 #include <cppally/sugar/r_make_vec.h>
+#include <cppally/sugar/r_sexp_methods.h>
 #include <string>
 
 namespace cppally {

--- a/inst/include/cppally/r_identical.h
+++ b/inst/include/cppally/r_identical.h
@@ -51,10 +51,10 @@ inline bool identical_impl(const r_sym& a, const r_sym& b) noexcept {
     return unwrap(a) == unwrap(b);
 }
 
+inline bool identical_impl(const r_sexp& a, const r_sexp& b);
+
 template <RComposite T>
 inline bool identical_impl(const T& a, const T& b);
-
-inline bool identical_impl(const r_sexp& a, const r_sexp& b);
 
 template <RVector T>
 inline bool identical_impl(const T& a, const T& b) {
@@ -106,30 +106,6 @@ inline bool identical_impl<r_df>(const r_df& a, const r_df& b) {
     return identical_impl(a.value, b.value);
 }
 
-inline bool identical_impl(const r_sexp& a, const r_sexp& b) {
-    SEXP x = unwrap(a);
-    SEXP y = unwrap(b);
-    if (x == y) return true; // same pointer
-    
-    // Visit both SEXP
-    return view_sexp(a, [&b](const auto& vec1) -> bool {
-        using vec1_t = decltype(vec1);
-
-        if constexpr (is<vec1_t, r_sexp>){
-            return R_compute_identical(vec1, b, 16);
-        } else {
-            return view_sexp(b, [&vec1](const auto& vec2) -> bool {
-                using vec2_t = decltype(vec2);
-
-                if constexpr (!is<vec1_t, vec2_t>){
-                    return false;
-                } else {
-                    return identical_impl(vec1, vec2);
-                }
-            });
-        }
-        });
-}
 
 inline bool identical_impl(SEXP a, SEXP b) {
     return identical_impl(r_sexp(a, view_tag{}), r_sexp(b, view_tag{}));

--- a/inst/include/cppally/r_length.h
+++ b/inst/include/cppally/r_length.h
@@ -23,9 +23,7 @@ inline r_size_t length(const r_sym& x) noexcept {
     return 1;
 }
 
-inline r_size_t length(const r_sexp& x) {
-    return CPPALLY_VIEW_AND_APPLY(x, /*return_type = */ r_size_t, /*fn = */ length);
-}
+inline r_size_t length(const r_sexp& x);
 
 inline bool is_long(SEXP x){
     return length(r_sexp(x, internal::view_tag{})) > static_cast<r_size_t>(std::numeric_limits<int>::max());

--- a/inst/include/cppally/r_list_helpers.h
+++ b/inst/include/cppally/r_list_helpers.h
@@ -2,8 +2,7 @@
 #define CPPALLY_R_LIST_HELPERS_H
 
 #include <cppally/r_vec.h>
-#include <cppally/r_visit.h>
-#include <cppally/r_length.h>
+#include <cppally/sugar/r_sexp_methods.h>
 #include <cppally/sugar/r_rep.h>
 
 namespace cppally {

--- a/inst/include/cppally/r_raw.h
+++ b/inst/include/cppally/r_raw.h
@@ -14,8 +14,8 @@ struct r_raw {
     constexpr r_raw() : value{static_cast<unsigned char>(0)} {}
 
     // Conversion handling
-    explicit constexpr r_raw(unsigned char x) : value{x} {}
-    constexpr operator unsigned char() const { return value; }
+    explicit constexpr r_raw(unsigned char x) noexcept : value{x} {}
+    constexpr operator unsigned char() const noexcept { return value; }
 };
 
 }

--- a/inst/include/cppally/r_types.h
+++ b/inst/include/cppally/r_types.h
@@ -27,7 +27,7 @@ namespace cppally {
 
 // Recursively unwrap until we hit a primitive type
 template <typename T>
-inline constexpr auto unwrap(const T& x){
+inline constexpr unwrap_t<T> unwrap(const T& x) noexcept {
 if constexpr (RVal<T>){
     return unwrap(x.value);
   } else if constexpr (RObject<T>){

--- a/inst/include/cppally/r_types.h
+++ b/inst/include/cppally/r_types.h
@@ -25,16 +25,13 @@
 
 namespace cppally {
 
-// Recursively unwrap until we hit a primitive type
 template <typename T>
 inline constexpr unwrap_t<T> unwrap(const T& x) noexcept {
-if constexpr (RVal<T>){
-    return unwrap(x.value);
-  } else if constexpr (RObject<T>){
-    return static_cast<SEXP>(x);
-  } else {
-    return x;
-  }
+  // T must be convertible (implicitly or explicitly) to unwrap_t<T>
+  // unwrap_t<> is a well-defined trait which handles the mapping
+  // It also asserts that it is a non-throwable construction
+  static_assert(std::is_nothrow_constructible_v<unwrap_t<T>, const T&>);
+  return static_cast<unwrap_t<T>>(x);
 }
 
 // Coerce C/C++ types to RScalar

--- a/inst/include/cppally/sugar/r_combine.h
+++ b/inst/include/cppally/sugar/r_combine.h
@@ -6,6 +6,7 @@
 #include <cppally/sugar/r_subset.h>
 #include <cppally/sugar/r_rep.h>
 #include <cppally/sugar/r_make_vec.h>
+#include <cppally/sugar/r_sexp_methods.h>
 
 namespace cppally {
 

--- a/inst/include/cppally/sugar/r_fill.h
+++ b/inst/include/cppally/sugar/r_fill.h
@@ -82,25 +82,10 @@ void fill(r_factors& x, const r_vec<U>& where, const r_factors& with) {
 // }
 
 template <internal::RSubscript U, typename V>
-void fill(r_sexp& x, const r_vec<U>& where, const V& with) {
-  mutate_sexp(x, [&](auto& x_) {
-    using x_t = std::remove_cvref_t<decltype(x_)>;
-    if constexpr (is<x_t, r_sexp>){
-        abort("Unsupported SEXP type in `fill()`");
-    } else if constexpr (requires { fill(x_, where, with); }){
-        fill(x_, where, with);
-    } else {
-        abort("No available method for type %s in `fill()`", internal::type_str<std::remove_cvref_t<decltype(x_)>>());
-    }
-  });
-}
+void fill(r_sexp& x, const r_vec<U>& where, const V& with);
 
 template <internal::RSubscript U>
-void fill(r_sexp& x, const r_vec<U>& where, const r_sexp& with) {
-  visit_sexp(with, [&](const auto& with_) {
-    fill(x, where, with_);
-  });
-}
+void fill(r_sexp& x, const r_vec<U>& where, const r_sexp& with);
 
 }
 

--- a/inst/include/cppally/sugar/r_find.h
+++ b/inst/include/cppally/sugar/r_find.h
@@ -61,9 +61,7 @@ inline r_vec<r_int> find(const r_df& x, const r_df& rows, bool invert = false){
 
 template <typename T, typename U, internal::RNumericSubscript V = r_int>
 requires (is<T, r_sexp> || is<U, r_sexp>)
-inline r_vec<V> find(const T& x, const U& values, bool invert = false) {
-  return CPPALLY_VIEW_PAIR_AND_APPLY(x, values, r_vec<V>, find, invert);
-}
+inline r_vec<V> find(const T& x, const U& values, bool invert = false);
 
 }
 

--- a/inst/include/cppally/sugar/r_groups.h
+++ b/inst/include/cppally/sugar/r_groups.h
@@ -451,9 +451,7 @@ inline groups make_groups(const r_df& x, bool ordered = false) {
     }
 }
 
-inline groups make_groups(const r_sexp& x, bool ordered){
-    return CPPALLY_VIEW_AND_APPLY(x, /*return_type = */ groups, /*fn = */ make_groups, /*rest of args = */ ordered);
-}
+inline groups make_groups(const r_sexp& x, bool ordered);
 
 }
 

--- a/inst/include/cppally/sugar/r_hash.h
+++ b/inst/include/cppally/sugar/r_hash.h
@@ -119,11 +119,8 @@ inline uint64_t r_hash_impl(const r_factors& x) noexcept {
 };
 
 
-// Specialization for elements of lists
-template<>
-inline uint64_t r_hash_impl(const r_sexp& x) noexcept {
-    return CPPALLY_VIEW_AND_APPLY(x, /*return_type = */ uint64_t, /*fn = */ r_hash_impl);
-};
+// Overload for elements of lists — defined in sugar/r_sexp_methods.h
+inline uint64_t r_hash_impl(const r_sexp& x) noexcept;
 
 
 template <typename T>

--- a/inst/include/cppally/sugar/r_match.h
+++ b/inst/include/cppally/sugar/r_match.h
@@ -224,12 +224,6 @@ inline r_vec<r_int> match(const r_factors& needles, const r_factors& haystack, r
   }
 }
 
-template <typename T, typename U>
-requires (is<T, r_sexp> || is<U, r_sexp>)
-inline r_vec<r_int> match(const T& x, const U& y, r_int no_match) {
-  return CPPALLY_VIEW_PAIR_AND_APPLY(x, y, r_vec<r_int>, match, no_match);
-}
-
 template <RVal T>
 r_factors::r_factors(const r_vec<T>& x, const r_vec<T>& levels) : value(match(x, levels)){
 

--- a/inst/include/cppally/sugar/r_n_unique.h
+++ b/inst/include/cppally/sugar/r_n_unique.h
@@ -46,9 +46,7 @@ inline r_size_t n_unique(const r_df& x) {
   return make_groups(x, false).n_groups;
 }
 
-inline r_size_t n_unique(const r_sexp& x) {
-  return CPPALLY_VIEW_AND_APPLY(x, /*return_type = */ r_size_t, /*fn = */ n_unique);
-}
+inline r_size_t n_unique(const r_sexp& x);
 
 }
 

--- a/inst/include/cppally/sugar/r_remove.h
+++ b/inst/include/cppally/sugar/r_remove.h
@@ -44,9 +44,7 @@ inline r_factors remove(const r_factors& x, const r_factors& values){
 
 template <typename T, typename U>
 requires (is<T, r_sexp> || is<U, r_sexp>)
-inline T remove(const T& x, const U& values){
-  return as<T>(CPPALLY_VIEW_PAIR_AND_APPLY(x, values, SEXP, remove));
-}
+inline T remove(const T& x, const U& values);
 
 }
 

--- a/inst/include/cppally/sugar/r_rep.h
+++ b/inst/include/cppally/sugar/r_rep.h
@@ -34,9 +34,6 @@ inline r_df rep_len(const r_df& x, r_size_t n){
       return out;
 }
 
-inline r_sexp rep_len(const r_sexp& x, r_size_t n){
-    return r_sexp(CPPALLY_VIEW_AND_APPLY(x, /*return_type = */ SEXP, /*fn = */ rep_len, n));
-}
 
 template <RVector T>
 T resize(const T& x, r_size_t n){
@@ -65,9 +62,6 @@ inline r_df resize(const r_df& x, r_size_t n){
     return out;
 }
 
-inline r_sexp resize(const r_sexp& x, r_size_t n){
-    return r_sexp(CPPALLY_VIEW_AND_APPLY(x, /*return_type = */ SEXP, /*fn = */ resize, n));
-}
 
 template <RVector T>
 T rep(const T& x, const r_vec<r_int>& times){
@@ -113,9 +107,6 @@ inline r_df rep(const r_df& x, const r_vec<r_int>& times) {
     return out;
 }
 
-inline r_sexp rep(const r_sexp& x, const r_vec<r_int>& times) {
-    return r_sexp(CPPALLY_VIEW_AND_APPLY(x, /*return_type = */ SEXP, /*fn = */ rep, times));
-}
 
 template <RVector T>
 T rep_each(const T& x, const r_vec<r_int>& each){
@@ -144,9 +135,6 @@ inline r_df rep_each(const r_df& x, const r_vec<r_int>& each) {
     return out;
 }
 
-inline r_sexp rep_each(const r_sexp& x, const r_vec<r_int>& each) {
-    return r_sexp(CPPALLY_VIEW_AND_APPLY(x, /*return_type = */ SEXP, /*fn = */ rep_each, each));
-}
 
 }
 

--- a/inst/include/cppally/sugar/r_replace.h
+++ b/inst/include/cppally/sugar/r_replace.h
@@ -74,21 +74,6 @@ inline void replace(r_df& x, const r_df& old_values, const r_df& new_values){
 }
 
 
-template <typename U>
-inline void replace(r_sexp& x, const U& old_values, const U& new_values){
-  mutate_sexp(x, [&](auto& x_) {
-    using x_t = std::remove_cvref_t<decltype(x_)>;
-    x_t oldv = x_t(static_cast<SEXP>(old_values));
-    x_t newv = x_t(static_cast<SEXP>(new_values));
-    if constexpr (is<x_t, r_sexp>){
-        abort("Unsupported SEXP type in `replace()`");
-    } else if constexpr (requires { replace(x_, oldv, newv); }){
-      replace(x_, oldv, newv);
-    } else {
-      abort("No available method for type %s in `replace`", internal::type_str<x_t>());
-    }
-  });
-}
 
 }
 

--- a/inst/include/cppally/sugar/r_sexp_methods.h
+++ b/inst/include/cppally/sugar/r_sexp_methods.h
@@ -1,0 +1,174 @@
+#ifndef CPPALLY_R_SEXP_METHODS_H
+#define CPPALLY_R_SEXP_METHODS_H
+
+// Type-safe methods for r_sexp
+
+#include <cppally/r_visit.h>
+#include <cppally/r_length.h>
+#include <cppally/sugar/r_rep.h>
+#include <cppally/sugar/r_subset.h>
+#include <cppally/sugar/r_sort.h>
+#include <cppally/sugar/r_unique.h>
+#include <cppally/sugar/r_n_unique.h>
+#include <cppally/sugar/r_hash.h>
+#include <cppally/sugar/r_groups.h>
+#include <cppally/sugar/r_match.h>
+#include <cppally/sugar/r_find.h>
+#include <cppally/sugar/r_remove.h>
+#include <cppally/sugar/r_fill.h>
+#include <cppally/sugar/r_replace.h>
+#include <cppally/r_copy.h>
+#include <cppally/r_identical.h>
+
+namespace cppally {
+
+inline r_size_t length(const r_sexp& x) {
+    return CPPALLY_VIEW_AND_APPLY(x, /*return_type = */ r_size_t, /*fn = */ length);
+}
+
+inline r_sexp rep_len(const r_sexp& x, r_size_t n) {
+    return r_sexp(CPPALLY_VIEW_AND_APPLY(x, /*return_type = */ SEXP, /*fn = */ rep_len, n));
+}
+
+inline r_sexp resize(const r_sexp& x, r_size_t n) {
+    return r_sexp(CPPALLY_VIEW_AND_APPLY(x, /*return_type = */ SEXP, /*fn = */ resize, n));
+}
+
+inline r_sexp rep(const r_sexp& x, const r_vec<r_int>& times) {
+    return r_sexp(CPPALLY_VIEW_AND_APPLY(x, /*return_type = */ SEXP, /*fn = */ rep, times));
+}
+
+inline r_sexp rep_each(const r_sexp& x, const r_vec<r_int>& each) {
+    return r_sexp(CPPALLY_VIEW_AND_APPLY(x, /*return_type = */ SEXP, /*fn = */ rep_each, each));
+}
+
+template <internal::RSubscript U>
+inline r_sexp subset(const r_sexp& x, const r_vec<U>& indices, bool check, bool invert) {
+    return r_sexp(CPPALLY_VIEW_AND_APPLY(x, /*return_type = */ SEXP, /*fn = */ subset, /*rest of args = */ indices, check, invert));
+}
+
+inline r_vec<r_int> order(const r_sexp& x, bool preserve_ties) {
+    return CPPALLY_VIEW_AND_APPLY(x, /*return_type = */ r_vec<r_int>, /*fn = */ order, /*rest of args = */ preserve_ties);
+}
+
+inline r_vec<r_lgl> duplicated(const r_sexp& x, bool all) {
+    return CPPALLY_VIEW_AND_APPLY(x, /*return_type = */ r_vec<r_lgl>, /*fn = */ duplicated, /*rest of args = */ all);
+}
+
+inline r_size_t n_unique(const r_sexp& x) {
+    return CPPALLY_VIEW_AND_APPLY(x, /*return_type = */ r_size_t, /*fn = */ n_unique);
+}
+
+inline groups make_groups(const r_sexp& x, bool ordered) {
+    return CPPALLY_VIEW_AND_APPLY(x, /*return_type = */ groups, /*fn = */ make_groups, /*rest of args = */ ordered);
+}
+
+template <typename T, typename U>
+requires (is<T, r_sexp> || is<U, r_sexp>)
+inline r_vec<r_int> match(const T& x, const U& y, r_int no_match) {
+    return CPPALLY_VIEW_PAIR_AND_APPLY(x, y, r_vec<r_int>, match, no_match);
+}
+
+template <typename T, typename U>
+requires (is<T, r_sexp> || is<U, r_sexp>)
+inline T remove(const T& x, const U& values) {
+    return as<T>(CPPALLY_VIEW_PAIR_AND_APPLY(x, values, SEXP, remove));
+}
+
+template <typename T, typename U, internal::RNumericSubscript V>
+requires (is<T, r_sexp> || is<U, r_sexp>)
+inline r_vec<V> find(const T& x, const U& values, bool invert) {
+    return CPPALLY_VIEW_PAIR_AND_APPLY(x, values, r_vec<V>, find, invert);
+}
+
+template <internal::RSubscript U, typename V>
+void fill(r_sexp& x, const r_vec<U>& where, const V& with) {
+    mutate_sexp(x, [&](auto& x_) {
+        using x_t = std::remove_cvref_t<decltype(x_)>;
+        if constexpr (is<x_t, r_sexp>){
+            abort("Unsupported SEXP type in `fill()`");
+        } else if constexpr (requires { fill(x_, where, with); }){
+            fill(x_, where, with);
+        } else {
+            abort("No available method for type %s in `fill()`", internal::type_str<x_t>());
+        }
+    });
+}
+
+template <internal::RSubscript U>
+void fill(r_sexp& x, const r_vec<U>& where, const r_sexp& with) {
+    visit_sexp(with, [&](const auto& with_) {
+        fill(x, where, with_);
+    });
+}
+
+template <typename U>
+inline void replace(r_sexp& x, const U& old_values, const U& new_values) {
+    mutate_sexp(x, [&](auto& x_) {
+        using x_t = std::remove_cvref_t<decltype(x_)>;
+        x_t oldv = x_t(static_cast<SEXP>(old_values));
+        x_t newv = x_t(static_cast<SEXP>(new_values));
+        if constexpr (is<x_t, r_sexp>){
+            abort("Unsupported SEXP type in `replace()`");
+        } else if constexpr (requires { replace(x_, oldv, newv); }){
+            replace(x_, oldv, newv);
+        } else {
+            abort("No available method for type %s in `replace`", internal::type_str<x_t>());
+        }
+    });
+}
+
+template<>
+inline r_sexp deep_copy(const r_sexp& x) {
+    return view_sexp(x, [](const auto& vec) -> r_sexp {
+        if constexpr (!is<decltype(vec), r_sexp>){
+            return r_sexp(static_cast<SEXP>(deep_copy(vec)));
+        } else {
+            return r_sexp(safe[Rf_duplicate](vec));
+        }
+    });
+}
+
+template<>
+inline r_sexp shallow_copy(const r_sexp& x) {
+    return view_sexp(x, [](const auto& vec) -> r_sexp {
+        if constexpr (!is<decltype(vec), r_sexp>){
+            return r_sexp(static_cast<SEXP>(shallow_copy(vec)));
+        } else {
+            return r_sexp(safe[Rf_shallow_duplicate](vec));
+        }
+    });
+}
+
+} // namespace cppally
+
+namespace cppally::internal {
+
+inline bool identical_impl(const r_sexp& a, const r_sexp& b) {
+    SEXP x = unwrap(a);
+    SEXP y = unwrap(b);
+    if (x == y) return true;
+    return view_sexp(a, [&b](const auto& vec1) -> bool {
+        using vec1_t = decltype(vec1);
+        if constexpr (is<vec1_t, r_sexp>){
+            return R_compute_identical(vec1, b, 16);
+        } else {
+            return view_sexp(b, [&vec1](const auto& vec2) -> bool {
+                using vec2_t = decltype(vec2);
+                if constexpr (!is<vec1_t, vec2_t>){
+                    return false;
+                } else {
+                    return identical_impl(vec1, vec2);
+                }
+            });
+        }
+    });
+}
+
+inline uint64_t r_hash_impl(const r_sexp& x) noexcept {
+    return CPPALLY_VIEW_AND_APPLY(x, /*return_type = */ uint64_t, /*fn = */ r_hash_impl);
+}
+
+} // namespace cppally::internal
+
+#endif

--- a/inst/include/cppally/sugar/r_sort.h
+++ b/inst/include/cppally/sugar/r_sort.h
@@ -410,12 +410,7 @@ inline r_vec<r_int> order(const r_df& x, bool preserve_ties = true) {
 }
 
 
-inline r_vec<r_int> order(const r_sexp& x, bool preserve_ties) {
-    return CPPALLY_VIEW_AND_APPLY(
-        x, /*return_type = */ r_vec<r_int>, /*fn = */ order, 
-        /*rest of args = */ preserve_ties
-    );
-}
+inline r_vec<r_int> order(const r_sexp& x, bool preserve_ties);
 
 // Is x in a sorted order? i.e is x increasing but not necessarily monotonically?
 // To retrieve a bool result, use the `is_true` member function

--- a/inst/include/cppally/sugar/r_subset.h
+++ b/inst/include/cppally/sugar/r_subset.h
@@ -218,11 +218,6 @@ inline r_df subset(const r_df& x, const r_vec<r_int>& indices, bool check = true
   return r_df(out, false, length(out.view(0)));
 }
 
-template <internal::RSubscript U>
-inline r_sexp subset(const r_sexp& x, const r_vec<U>& indices, bool check, bool invert){
-  return r_sexp(CPPALLY_VIEW_AND_APPLY(x, /*return_type = */ SEXP, /*fn = */ subset, /*rest of args = */ indices, check, invert));
-}
-
 }
 
 #endif

--- a/inst/include/cppally/sugar/r_unique.h
+++ b/inst/include/cppally/sugar/r_unique.h
@@ -39,9 +39,7 @@ inline r_vec<r_lgl> duplicated(const r_df& x, bool all = false){
     return duplicated(make_groups(x, false).ids, all);
 }
 
-inline r_vec<r_lgl> duplicated(const r_sexp& x, bool all = false){
-    return CPPALLY_VIEW_AND_APPLY(x, /*return_type = */ r_vec<r_lgl>, /*fn = */ duplicated, /*rest of args = */ all);
-}
+inline r_vec<r_lgl> duplicated(const r_sexp& x, bool all = false);
 
 template <RVal T>
 r_factors::r_factors(const r_vec<T>& x) : r_factors(x, unique(x)) {}


### PR DESCRIPTION
Moved `r_sexp` methods into one header for easier maintenance.